### PR TITLE
ci(APE-1107): add explicit permissions to workflows

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
## Summary
- Added explicit `contents: write` permission to `create-release.yml` workflow (required for creating releases, pushing changes, and uploading assets)
- Added explicit `contents: read` permission to `pull_request.yml` workflow (required for checking out code)

## Rationale
GitHub recommends explicitly declaring workflow permissions to follow the principle of least privilege and improve security posture. This ensures workflows have only the permissions they need to function.

## Changes
- `.github/workflows/create-release.yml`: Added `contents: write` permission
- `.github/workflows/pull_request.yml`: Added `contents: read` permission

Relates to APE-1107